### PR TITLE
Exclude several false positives from filter lists

### DIFF
--- a/submit_here/kidsaf_exclude.txt
+++ b/submit_here/kidsaf_exclude.txt
@@ -18,3 +18,9 @@ privacy.sexy
 .dood.ws
 .dood.so
 .fastdrive.io
+hole.cert.pl
+.gnome.org
+shop.rewe-static.de
+.riffreporter.de
+.ardaudiothek.de
+blocklistproject.github.io


### PR DESCRIPTION
Added several domains that have wrongly been blocked to [kidsaf_exclude.txt](https://github.com/badmojr/addons_1Hosts/compare/main...realpixelcode:addons_1Hosts:main#diff-230fe3fe2949f44096578b220c0b617a1e2b506b9ad5a250f3f4f1e69d503655), in order to unblock them.

```
hole.cert.pl
.gnome.org
shop.rewe-static.de
.riffreporter.de
.ardaudiothek.de
blocklistproject.github.io
```

Fixes #11, #13, #14, #15, #16, #17.